### PR TITLE
ci: Use AWS provider in integration test

### DIFF
--- a/resources/test/terraform/random-import-stack/main.tf
+++ b/resources/test/terraform/random-import-stack/main.tf
@@ -1,17 +1,17 @@
 terraform {
   required_providers {
-    random = {
-      source  = "hashicorp/random"
-      version = "3.4.3"
-    }
     null = {
       source  = "hashicorp/null"
       version = "3.2.1"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.12.0"
+    }
   }
 }
 
-provider "random" {
+provider "aws" {
   # Configuration options
 }
 


### PR DESCRIPTION
Turns out the two providers I was using was not large enough to trigger an edge case in artifacts.rs due to their small size as they fit in a single multi part upload. I've swapped out one of the providers for the AWS provider to test "large" streaming uploads.