### PR TITLE
feat: Added API for adding credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,6 +579,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-macros"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdca6a10ecad987bda04e95606ef85a5417dcaac1a78455242d72e031e2b6b62"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
 name = "axum-prometheus"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2770,6 +2782,7 @@ dependencies = [
  "aws-endpoint",
  "aws-sdk-s3",
  "axum",
+ "axum-macros",
  "axum-prometheus",
  "clap",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ axum-prometheus = "0.4.0"
 async-trait = "0.1.72"
 
 [dev-dependencies]
+axum-macros = "0.3.8"
 tempfile = "3.7.0"
 tracing-test = { version = "0.2.4", features = ["no-env-filter"] }
 uuid = { version = "1.4.1", features = ["v4"] }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,4 @@
 ignore:
   - integration
+  - src/credhelper/memory.rs
+  - src/credhelper/faulty.rs

--- a/src/credhelper/faulty.rs
+++ b/src/credhelper/faulty.rs
@@ -1,0 +1,31 @@
+/// Implementation of the memory credential helper that always throws an error
+///
+/// This is useful for testing the error handling of the credential helper
+use async_trait::async_trait;
+
+use super::{Credential, CredentialHelper};
+
+#[derive(Clone, Debug)]
+pub(crate) struct FaultyCredentials;
+
+impl FaultyCredentials {
+    #[allow(dead_code)]
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl CredentialHelper for FaultyCredentials {
+    async fn get(&self, _hostname: impl AsRef<str> + Send) -> Result<Credential, anyhow::Error> {
+        Err(anyhow::anyhow!("Error occurred"))
+    }
+
+    async fn store(&mut self, _hostname: String, _cred: String) -> Result<(), anyhow::Error> {
+        Err(anyhow::anyhow!("Error occurred"))
+    }
+
+    async fn forget(&mut self, _hostname: impl AsRef<str> + Send) -> Result<(), anyhow::Error> {
+        Err(anyhow::anyhow!("Error occurred"))
+    }
+}

--- a/src/credhelper/mod.rs
+++ b/src/credhelper/mod.rs
@@ -1,4 +1,5 @@
 pub mod database;
+pub mod faulty;
 pub mod memory;
 mod types;
 

--- a/src/credhelper/types.rs
+++ b/src/credhelper/types.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use reqwest::RequestBuilder;
 use std::marker::Send;
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum Credential {
     NotFound,
     Entry(Option<String>),

--- a/src/http/api/mod.rs
+++ b/src/http/api/mod.rs
@@ -2,7 +2,7 @@ use axum::{routing::post, Router};
 
 use crate::credhelper::CredentialHelper;
 
-use self::v1::credential::{delete, update};
+use self::v1::credential::{delete, exists, update};
 
 pub(crate) mod v1;
 
@@ -15,6 +15,9 @@ pub(crate) fn routes<S, C: Clone + Send + Sync + 'static + CredentialHelper>(
     state: APIState<C>,
 ) -> Router<S> {
     Router::new()
-        .route("/api/v1/credentials/:hostname", post(update).delete(delete))
+        .route(
+            "/api/v1/credentials/:hostname",
+            post(update).delete(delete).get(exists),
+        )
         .with_state(state)
 }

--- a/src/http/api/mod.rs
+++ b/src/http/api/mod.rs
@@ -1,0 +1,20 @@
+use axum::{routing::post, Router};
+
+use crate::credhelper::CredentialHelper;
+
+use self::v1::credential::{delete, update};
+
+pub(crate) mod v1;
+
+#[derive(Clone)]
+pub(crate) struct APIState<C> {
+    pub(crate) credentials: C,
+}
+
+pub(crate) fn routes<S, C: Clone + Send + Sync + 'static + CredentialHelper>(
+    state: APIState<C>,
+) -> Router<S> {
+    Router::new()
+        .route("/api/v1/credentials/:hostname", post(update).delete(delete))
+        .with_state(state)
+}

--- a/src/http/api/v1/credential.rs
+++ b/src/http/api/v1/credential.rs
@@ -1,0 +1,135 @@
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use http::StatusCode;
+
+use crate::{credhelper::CredentialHelper, http::api::APIState};
+
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct UpdateRequest {
+    pub(crate) data: UpdateData,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct UpdateData {
+    pub(crate) token: String,
+}
+
+pub(crate) async fn update<C: CredentialHelper>(
+    State(APIState {
+        mut credentials, ..
+    }): State<APIState<C>>,
+    Path(hostname): Path<String>,
+    Json(UpdateRequest {
+        data: UpdateData { token: value },
+    }): Json<UpdateRequest>,
+) -> (StatusCode, String) {
+    match credentials.store(hostname, value).await {
+        Ok(_) => (
+            StatusCode::OK,
+            serde_json::to_string(&serde_json::json!({ "data": {} })).unwrap(),
+        ),
+        Err(e) => {
+            tracing::error!(reason=?e, "Error occurred updating credential");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                serde_json::to_string(
+                    &serde_json::json!({ "error": { "msg": "Error occurred updating credential" } }),
+                ).unwrap(),
+            )
+        }
+    }
+}
+
+pub(crate) async fn delete<C: CredentialHelper>(
+    State(APIState {
+        mut credentials, ..
+    }): State<APIState<C>>,
+    Path(hostname): Path<String>,
+) -> (StatusCode, String) {
+    match credentials.forget(&hostname).await {
+        Ok(_) => (
+            StatusCode::OK,
+            serde_json::to_string(&serde_json::json!({ "data": {} })).unwrap(),
+        ),
+        Err(e) => {
+            tracing::error!(reason=?e, "Error occurred deleting credential");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                serde_json::to_string(
+                    &serde_json::json!({ "error": { "msg": "Error occurred deleting credential" } }),
+                )
+                .unwrap(),
+            )
+        }
+    }
+}
+
+// Testing the update and delete of the credentials
+#[cfg(test)]
+mod tests {
+    use tower::ServiceExt;
+    use tracing_test::traced_test;
+
+    use super::*;
+    use crate::{
+        credhelper::{memory::MemoryCredentials, Credential},
+        http::api::routes,
+    };
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_update_credential_for_hostname() {
+        let credentials = MemoryCredentials::default();
+        let state = APIState {
+            credentials: credentials.clone(),
+        };
+        let request = axum::http::Request::builder()
+            .method("POST")
+            .uri("/api/v1/credentials/example.com")
+            .header("content-type", "application/json")
+            .body(
+                r#"{
+                    "data": {
+                        "token": "password1"
+                    }
+                }"#
+                .into(),
+            )
+            .unwrap();
+        let response = routes(state).oneshot(request).await.unwrap();
+        assert!(response.status().is_success());
+
+        assert_eq!(
+            credentials.get("example.com").await.unwrap(),
+            Credential::Entry(Some("password1".into()))
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_delete_credential_for_hostname() {
+        let mut credentials = MemoryCredentials::default();
+        credentials
+            .store("example.com".into(), "password1".into())
+            .await
+            .unwrap();
+
+        let state = APIState {
+            credentials: credentials.clone(),
+        };
+        let request = axum::http::Request::builder()
+            .method("DELETE")
+            .uri("/api/v1/credentials/example.com")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let response = routes(state).oneshot(request).await.unwrap();
+        assert!(response.status().is_success());
+
+        assert_eq!(
+            credentials.get("example.com").await.unwrap(),
+            Credential::NotFound
+        );
+    }
+}

--- a/src/http/api/v1/mod.rs
+++ b/src/http/api/v1/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod credential;

--- a/src/http/artifacts.rs
+++ b/src/http/artifacts.rs
@@ -53,7 +53,7 @@ impl IntoResponse for ArtifactResponse {
     }
 }
 
-pub(crate) async fn artifacts_handler(
+pub(crate) async fn artifacts_handler<C>(
     State(AppState {
         http_client: http,
         registry_client: registry,
@@ -61,7 +61,7 @@ pub(crate) async fn artifacts_handler(
         s3_client: s3,
         config: args,
         ..
-    }): State<AppState>,
+    }): State<AppState<C>>,
     Path(version_id): Path<i64>,
 ) -> Result<impl IntoResponse, StatusCode> {
     tracing::debug!("Get artifact details from database");

--- a/src/http/index.rs
+++ b/src/http/index.rs
@@ -23,12 +23,12 @@ use tracing::Span;
 
 use super::response_types::MirrorIndex;
 
-pub(crate) async fn index_handler(
+pub(crate) async fn index_handler<C>(
     State(AppState {
         db_client: db,
         refresher_tx: tx,
         ..
-    }): State<AppState>,
+    }): State<AppState<C>>,
     Path((hostname, namespace, provider_type)): Path<(String, String, String)>,
 ) -> Result<MirrorIndex, TerrashineError> {
     match list_provider_versions(&db, &hostname, &namespace, &provider_type).await {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod api;
 pub(crate) mod artifacts;
 pub(crate) mod healthcheck;
 pub(crate) mod index;

--- a/src/http/version.rs
+++ b/src/http/version.rs
@@ -12,12 +12,12 @@ use tokio_stream::StreamExt;
 
 use super::response_types::{MirrorVersion, TargetPlatformIdentifier};
 
-pub(crate) async fn version_handler<'a>(
+pub(crate) async fn version_handler<'a, C>(
     State(AppState {
         db_client: db,
         config: args,
         ..
-    }): State<AppState>,
+    }): State<AppState<C>>,
     Path((hostname, namespace, provider_type, version)): Path<(String, String, String, Version)>,
 ) -> Result<MirrorVersion, StatusCode> {
     let downloads_result =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,11 +71,14 @@ pub async fn run(
         }
     };
 
+    // Set up credentials
+    let credentials = DatabaseCredentials::new(db.clone());
+
     let refresher_db = db.clone();
     let refresher_registry = RegistryClient::new(
         config.upstream_registry_port,
         http.clone(),
-        DatabaseCredentials::new(db.clone()),
+        credentials.clone(),
     );
     let refresher = refresher(
         &refresher_db,
@@ -86,7 +89,10 @@ pub async fn run(
     );
 
     let bind_addr = config.http_listen;
-    let app = app::provider_mirror_app(AppState::new(config, s3, db, http, tx), metric_handle);
+    let app = app::provider_mirror_app(
+        AppState::new(config, s3, db, http, tx, credentials.clone()),
+        metric_handle,
+    );
 
     let server = axum::Server::bind(&bind_addr).serve(app.into_make_service());
 


### PR DESCRIPTION
Implemented POST and DELETE methods to allow credentials to be modified via HTTP. The GET method intentionally does not respond with the credential as there's never a reason inserted credentials should be readable after the initial insert. So as a additional security measure, the GET only determines if the credential exists or not.