### PR TITLE
feat!: Move location of terraform provider endpoint

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -3,5 +3,5 @@
 - [Introduction](./introduction.md)
 - [Reverse proxy](./reverse-proxy.md)
 - [Database migrations](./database-migrations.md)
-- [Mirror refreshing](./mirror-refreshing.md)
 - [Private Registry Authentication](./private-registry-authentication.md)
+- [Mirror refreshing](./mirror-refreshing.md)

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -27,6 +27,26 @@ See the `--help` for more information:
 ./terrashine --help
 ```
 
+# Client configuration
+
+Once terrashine is all setup, the terraform client needs to be configured to use the mirror.
+This can be done a terraform configuration file entry.
+
+* On linux and MacOS, a `.terraformrc` file should created in the home directory.
+* On Windows `terraform.rc` file should be created in the `%APPDATA%` directory.
+
+This file should contain configuration to point terraform at the installed provider mirror.
+
+```
+provider_installation {
+  network_mirror {
+    url = "https://example.com/mirror/v1/"
+  }
+}
+```
+
+For more information on the terraform configuration file, see the [CLI Configuration File](https://developer.hashicorp.com/terraform/cli/config/config-file#provider-installation) docs from hashicorp.
+
 ## High availability
 
 Multiple instances of terrashine can be deployed to support high availability.

--- a/integration/main.rs
+++ b/integration/main.rs
@@ -66,7 +66,7 @@ fn test_end_to_end_terraform_flow(_: PoolOptions<Postgres>, db_options: PgConnec
         s3_bucket_name: "terrashine".to_string(),
         s3_bucket_prefix: prefix,
         s3_endpoint: Some(Url::parse("http://localhost:9000").unwrap()),
-        http_redirect_url: Url::parse("https://localhost:9443/").unwrap(),
+        http_redirect_url: Url::parse("https://localhost:9443/mirror/v1/").unwrap(),
         http_listen: SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 9543),
         refresh_interval: Duration::from_secs(10),
         upstream_registry_port: 443,

--- a/resources/test/terraform/random-import-stack/terraform.tfrc
+++ b/resources/test/terraform/random-import-stack/terraform.tfrc
@@ -1,5 +1,5 @@
 provider_installation {
   network_mirror {
-    url = "https://localhost:9443/"
+    url = "https://localhost:9443/mirror/v1/"
   }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -97,6 +97,15 @@ pub(crate) fn provider_mirror_app<C: Clone + Send + Sync + CredentialHelper + 's
             get(version_handler),
         )
         .route("/artifacts/:version_id", get(artifacts_handler))
+        .route(
+            "/mirror/v1/:hostname/:namespace/:provider_type/index.json",
+            get(index_handler),
+        )
+        .route(
+            "/mirror/v1/:hostname/:namespace/:provider_type/:version",
+            get(version_handler),
+        )
+        .route("/mirror/v1/artifacts/:version_id", get(artifacts_handler))
         .route("/healthcheck", get(healthcheck_handler))
         .route(
             "/metrics",

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,13 +107,13 @@ mod tests {
     // Test URL validation
     #[tokio::test]
     async fn test_url_validation() {
-        let url = "https://example.com";
+        let url = "https://example.com/mirror/v1";
         assert!(validate_redirect_url(url).is_err());
 
         let url = "/provider/";
         assert!(validate_redirect_url(url).is_err());
 
-        let url = "https://example.com/";
+        let url = "https://example.com/mirror/v1/";
         assert!(validate_redirect_url(url).is_ok());
     }
 


### PR DESCRIPTION
This is being done to segregate mirror endpoints from other endpoints such as API endpoints.
We are doing this early in the project to prevent issues with namespacing in the future (i.e. imagine a hostname being hosted at `api` on an internal network).
To allow users to migrate from the old location, we will make one release to simultaneously support the endpoints at the old location which could be deployed as a stepping stone release so no downtime is incurred from a version upgrade.