### PR TITLE
ci: Update renovate to remove AWS SDK

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,13 +4,6 @@
     ],
     "packageRules": [
         {
-            "matchSourceUrls": [
-                "https://github.com/awslabs/smithy-rs",
-                "https://github.com/awslabs/aws-sdk-rust",
-            ],
-            "groupName": "aws-sdk-rust",
-        },
-        {
             "matchPackagePrefixes": [
                 "tokio",
             ],


### PR DESCRIPTION
This has been upstreamed to renovate proper

https://github.com/renovatebot/renovate/pull/25508