### PR TITLE
fix: Fixed performance impact from switching to musl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,6 +1594,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2966,6 +2986,7 @@ dependencies = [
  "humantime",
  "hyper 1.1.0",
  "hyper-util",
+ "jemallocator",
  "lazy_static",
  "reqwest",
  "rustls-native-certs 0.7.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ hyper-util = { version = "0.1.1", features = [
     "server-auto",
 ] }
 rustls-native-certs = "0.7.0"
+jemallocator = "0.5.4"
 
 [dev-dependencies]
 axum-macros = "0.4.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,14 @@ use axum_prometheus::{
     AXUM_HTTP_REQUESTS_DURATION_SECONDS,
 };
 use clap::Parser;
+use jemallocator::Jemalloc;
 use terrashine::{config::Args, run};
 use tokio::{select, signal::unix::SignalKind, task};
 use tokio_util::sync::CancellationToken;
 use tracing_subscriber::EnvFilter;
+
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
Switching to musl seems to have impacted performance from the allocator. This restores it. (~10000 rqps -> ~16000 rqps)