### PR TITLE
feat: Updated CLI syntax to use subcommands

### DIFF
--- a/docs/src/starting-terrashine.md
+++ b/docs/src/starting-terrashine.md
@@ -16,5 +16,5 @@ A TLS terminating reverse proxy hosted is on `example.com` in this setup.
 Note that the `/mirror/v1/`  path is required in the URL to allow the backend server to serve up redirects correctly.
 
 ```
-AWS_REGION=eu-west-1 AWS_ACCESS_KEY_ID=xxx AWS_SECRET_ACCESS_KEY=xxx RUST_LOG=info  ./terrashine  --s3-bucket-name terrashine-example-test-1111  --http-redirect-url https://example.com/mirror/v1/
+AWS_REGION=eu-west-1 AWS_ACCESS_KEY_ID=xxx AWS_SECRET_ACCESS_KEY=xxx RUST_LOG=info  ./terrashine  server --s3-bucket-name terrashine-example-test-1111  --http-redirect-url https://example.com/mirror/v1/
 ```

--- a/integration/main.rs
+++ b/integration/main.rs
@@ -12,7 +12,7 @@ use std::{
 use crate::util::copy_dir;
 use reqwest::StatusCode;
 use sqlx::{pool::PoolOptions, postgres::PgConnectOptions, Postgres};
-use terrashine::{self, config::Args};
+use terrashine::{self, config::ServerArgs};
 use tokio::select;
 use tracing_test::traced_test;
 use url::Url;
@@ -22,7 +22,7 @@ use uuid::Uuid;
 #[sqlx::test]
 fn test_server_startup(_: PoolOptions<Postgres>, db_options: PgConnectOptions) {
     let prefix = format!("{}/", Uuid::new_v4());
-    let config = Args {
+    let config = ServerArgs {
         database_url: db_options,
         database_pool: 3,
         s3_bucket_name: "terrashine".to_string(),
@@ -35,7 +35,7 @@ fn test_server_startup(_: PoolOptions<Postgres>, db_options: PgConnectOptions) {
     };
     let cancellation_token = tokio_util::sync::CancellationToken::new();
     let (tx, rx) = tokio::sync::oneshot::channel();
-    let handle = tokio::spawn(terrashine::run(
+    let handle = tokio::spawn(terrashine::run_server(
         config,
         None,
         cancellation_token.child_token(),
@@ -61,7 +61,7 @@ fn test_server_startup(_: PoolOptions<Postgres>, db_options: PgConnectOptions) {
 #[sqlx::test]
 fn test_end_to_end_terraform_flow(_: PoolOptions<Postgres>, db_options: PgConnectOptions) {
     let prefix = format!("{}/", Uuid::new_v4());
-    let config = Args {
+    let config = ServerArgs {
         database_url: db_options,
         database_pool: 3,
         s3_bucket_name: "terrashine".to_string(),
@@ -74,7 +74,7 @@ fn test_end_to_end_terraform_flow(_: PoolOptions<Postgres>, db_options: PgConnec
     };
     let cancellation_token = tokio_util::sync::CancellationToken::new();
     let (tx, rx) = tokio::sync::oneshot::channel();
-    let handle = tokio::spawn(terrashine::run(
+    let handle = tokio::spawn(terrashine::run_server(
         config,
         None,
         cancellation_token.child_token(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use tracing::Level;
 
 use crate::http::api::APIState;
 use crate::{
-    config::Args,
+    config::ServerArgs,
     credhelper::{database::DatabaseCredentials, CredentialHelper},
     http::artifacts::artifacts_handler,
     http::healthcheck::healthcheck_handler,
@@ -28,14 +28,14 @@ pub(crate) struct AppState<C> {
     pub(crate) http_client: reqwest::Client,
     pub(crate) db_client: Pool<Postgres>,
     pub(crate) registry_client: RegistryClient<DatabaseCredentials>,
-    pub(crate) config: Args,
+    pub(crate) config: ServerArgs,
     pub(crate) refresher_tx: mpsc::Sender<RefreshRequest>,
     pub(crate) credentials: C,
 }
 
 impl<C> AppState<C> {
     pub(crate) fn new(
-        config: Args,
+        config: ServerArgs,
         s3: aws_sdk_s3::Client,
         db: Pool<Postgres>,
         http: reqwest::Client,

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,13 @@ fn parse_humantime(s: &str) -> Result<Duration, anyhow::Error> {
 
 #[derive(Parser, Debug, Clone)]
 #[command(author, version, about, long_about = None)]
-pub struct Args {
+pub enum Args {
+    Server(ServerArgs),
+}
+
+#[derive(clap::Args, Debug, Clone)]
+#[command(author, version, about, long_about = None)]
+pub struct ServerArgs {
     /// Socket to listen on
     ///
     /// The host and port to bind the HTTP service
@@ -122,6 +128,7 @@ mod tests {
     async fn test_clap_cli_parsing() {
         let _ = Args::try_parse_from([
             "./terrashine",
+            "server",
             "--http-redirect-url",
             "https://example.com/",
             "--s3-bucket-name",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use app::AppState;
 use aws_config::BehaviorVersion;
 use axum::extract::Request;
 use axum_prometheus::metrics_exporter_prometheus::PrometheusHandle;
-use config::Args;
+use config::{Args, ServerArgs};
 use hyper::body::Incoming;
 use hyper_util::{
     rt::{TokioExecutor, TokioIo},
@@ -71,6 +71,17 @@ async fn serve(listener: TcpListener, app: axum::Router) {
 
 pub async fn run(
     config: Args,
+    metric_handle: Option<PrometheusHandle>,
+    cancel: CancellationToken,
+    startup: Sender<StartUpNotify>,
+) -> Result<(), ()> {
+    match config {
+        Args::Server(args) => run_server(args, metric_handle, cancel, startup).await,
+    }
+}
+
+pub async fn run_server(
+    config: ServerArgs,
     metric_handle: Option<PrometheusHandle>,
     cancel: CancellationToken,
     startup: Sender<StartUpNotify>,


### PR DESCRIPTION
This is being done to support migrations directly in the binary.

BREAKING CHANGE: Changing CLI syntax to use subcommands.