### PR TITLE
multistage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+*
+!.cargo
+!.sqlx
+!Cargo.lock
+!Cargo.toml
+!migrations
+!src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/rust:1.82@sha256:81584ce20ac0fc77ac45384c28f356cb76489e8c71998962fed0008dbe496987
+FROM docker.io/library/rust:1.88@sha256:5771a3cc2081935c59ac52b92d49c9e164d4fed92c9f6420aa8cc50364aead6e AS build
 
 WORKDIR /app
 
@@ -11,6 +11,10 @@ COPY Cargo* .
 RUN cargo fetch
 COPY . .
 RUN SQLX_OFFLINE=1 cargo build --release
-RUN mv ./target/x86_64-unknown-linux-musl/release/terrashine /usr/bin/terrashine
+
+FROM docker.io/library/alpine:3.22.0
+
+COPY --from=build /app/target/x86_64-unknown-linux-musl/release/terrashine /usr/bin/terrashine
+
 ENV RUST_LOG=info
 CMD ["terrashine", "server"]


### PR DESCRIPTION
Reduces the size of the image from ~2G to ~150M.
Also improves build caching.