### PR TITLE
Utilize ENTRYPOINT in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,5 @@ FROM docker.io/library/alpine:3.22.0
 COPY --from=build /app/target/x86_64-unknown-linux-musl/release/terrashine /usr/bin/terrashine
 
 ENV RUST_LOG=info
-CMD ["terrashine", "server"]
+ENTRYPOINT ["terrashine"]
+CMD ["server"]


### PR DESCRIPTION
Small quality-of-life improvement. `terrashine` won't have to be repeated if command/arguments are changed.